### PR TITLE
Feature/fix 12 (Retry)

### DIFF
--- a/lib/mswp/cli.rb
+++ b/lib/mswp/cli.rb
@@ -22,11 +22,11 @@ module MSwp
 
       begin
         CursesGame.start(size_, mines_count, auto)
-      rescue MSwp::IllegalMinesCountSpecified # FIXME: this rescue doesn't work
+      rescue MSwp::IllegalMinesCountSpecified
         abort("Error: illegal mines count specified")
-      rescue MSwp::TooManyMinesCountSpecified # FIXME: this rescue doesn't work
+      rescue MSwp::TooManyMinesCountSpecified
         abort("Error: too many mines count specified")
-      rescue MSwp::IllegalSizeSpecified, CursesGame::IllegalSizeSpecified # FIXME: this rescue doesn't work
+      rescue MSwp::IllegalSizeSpecified, CursesGame::IllegalSizeSpecified
         abort("Error: illegal size specified")
       end
     end

--- a/lib/mswp/game.rb
+++ b/lib/mswp/game.rb
@@ -9,9 +9,9 @@ module MSwp
     end
 
     def start(size, mines_count, auto)
-      init_game(size)
-
       mswp = MSwp.new(size, mines_count)
+
+      init_game(size)
 
       th = start_timer_thread
 


### PR DESCRIPTION
This PR fixes #12 . The cause of #12 was that the error messages are tried to print after `Curses.init_screen` is called, so that just printed messages are hidden by curses.

To fix it, I swapped the order of calling `init_game` and `MSwp.new`.